### PR TITLE
Hotfix/cs/multi records bugs

### DIFF
--- a/build_data.json
+++ b/build_data.json
@@ -1,1 +1,1 @@
-{"date": "2017-12-22 18:24:40.439507", "commit": "63ffcb8", "command": "build_dlkit.py --buildto dlkit-pip/dlkit", "user": "cjshaw"}
+{"date": "2017-12-27 16:52:46.197181", "commit": "83aebe2", "command": "build_dlkit.py --buildto dlkit-pip/dlkit", "user": "cjshaw"}

--- a/dlkit/json_/assessment/profile.py
+++ b/dlkit/json_/assessment/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo assessment'
 
 DESCRIPTION = 'MongoDB based assessment implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/assessment_authoring/profile.py
+++ b/dlkit/json_/assessment_authoring/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo assessment.authoring'
 
 DESCRIPTION = 'MongoDB based assessment.authoring implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/authentication/profile.py
+++ b/dlkit/json_/authentication/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo authentication'
 
 DESCRIPTION = 'MongoDB based authentication implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/authentication_process/profile.py
+++ b/dlkit/json_/authentication_process/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo authentication.process'
 
 DESCRIPTION = 'MongoDB based authentication.process implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/authorization/profile.py
+++ b/dlkit/json_/authorization/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo authorization'
 
 DESCRIPTION = 'MongoDB based authorization implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/cataloging/profile.py
+++ b/dlkit/json_/cataloging/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo cataloging'
 
 DESCRIPTION = 'MongoDB based cataloging implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/commenting/profile.py
+++ b/dlkit/json_/commenting/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo commenting'
 
 DESCRIPTION = 'MongoDB based commenting implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/grading/profile.py
+++ b/dlkit/json_/grading/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo grading'
 
 DESCRIPTION = 'MongoDB based grading implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/hierarchy/profile.py
+++ b/dlkit/json_/hierarchy/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo hierarchy'
 
 DESCRIPTION = 'MongoDB based hierarchy implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/id/profile.py
+++ b/dlkit/json_/id/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo id'
 
 DESCRIPTION = 'MongoDB based id implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/learning/profile.py
+++ b/dlkit/json_/learning/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo learning'
 
 DESCRIPTION = 'MongoDB based learning implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/locale/profile.py
+++ b/dlkit/json_/locale/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo locale'
 
 DESCRIPTION = 'MongoDB based locale implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/logging_/profile.py
+++ b/dlkit/json_/logging_/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo logging'
 
 DESCRIPTION = 'MongoDB based logging implementation'
 
-VERSIONCOMPONENTS = [0, 1, 129]
+VERSIONCOMPONENTS = [0, 1, 130]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/osid/profile.py
+++ b/dlkit/json_/osid/profile.py
@@ -17,8 +17,8 @@ DISPLAYNAME = 'Mongo osid'
 
 DESCRIPTION = 'MongoDB based osid implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = ['# Remove the # when implementations exist:', '#supports_journal_rollback', '#supports_journal_branching']

--- a/dlkit/json_/osid/record_templates.py
+++ b/dlkit/json_/osid/record_templates.py
@@ -27,6 +27,10 @@ class OsidRecord(abc_osid_records.OsidRecord):
         if not block_super:
             super(OsidRecord, self)._init_map(**kwargs)
 
+    @staticmethod
+    def _block_super(kwargs):
+        return 'block_super' in kwargs and kwargs['block_super']
+
     # def __init__(self):
     #     # This is set in implemented Records.  Should super __init__
     #     # self._implemented_record_type_identifiers = None

--- a/dlkit/json_/proxy/profile.py
+++ b/dlkit/json_/proxy/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo proxy'
 
 DESCRIPTION = 'MongoDB based proxy implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/relationship/profile.py
+++ b/dlkit/json_/relationship/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo relationship'
 
 DESCRIPTION = 'MongoDB based relationship implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/repository/profile.py
+++ b/dlkit/json_/repository/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo repository'
 
 DESCRIPTION = 'MongoDB based repository implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/resource/profile.py
+++ b/dlkit/json_/resource/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo resource'
 
 DESCRIPTION = 'MongoDB based resource implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/json_/type/profile.py
+++ b/dlkit/json_/type/profile.py
@@ -17,9 +17,9 @@ DISPLAYNAME = 'Mongo type'
 
 DESCRIPTION = 'MongoDB based type implementation'
 
-VERSIONCOMPONENTS = [0, 1, 128]
+VERSIONCOMPONENTS = [0, 1, 129]
 
-RELEASEDATE = "2017-12-22"
+RELEASEDATE = "2017-12-27"
 
 SUPPORTS = [  # 'Remove the # when implementations exist:'
     # 'supports_journal_rollback',

--- a/dlkit/records/adaptive/magic_parts/assessment_part_records.py
+++ b/dlkit/records/adaptive/magic_parts/assessment_part_records.py
@@ -454,7 +454,8 @@ class ScaffoldDownAssessmentPartFormRecord(abc_assessment_authoring_records.Asse
     ]
 
     def __init__(self, **kwargs):
-        super(ScaffoldDownAssessmentPartFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ScaffoldDownAssessmentPartFormRecord, self).__init__(**kwargs)
         self._item_ids_metadata = None
         self._learning_objective_ids_metadata = None
         self._max_levels_metadata = None
@@ -464,7 +465,8 @@ class ScaffoldDownAssessmentPartFormRecord(abc_assessment_authoring_records.Asse
         self._allow_repeat_items_metadata = None
 
     def _init_metadata(self, **kwargs):
-        super(ScaffoldDownAssessmentPartFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ScaffoldDownAssessmentPartFormRecord, self)._init_metadata(**kwargs)
         self._item_ids_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -571,7 +573,8 @@ class ScaffoldDownAssessmentPartFormRecord(abc_assessment_authoring_records.Asse
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(ScaffoldDownAssessmentPartFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ScaffoldDownAssessmentPartFormRecord, self)._init_map(**kwargs)
         self._my_map['itemIds'] = \
             [str(self._item_ids_metadata['default_id_values'][0])]
         self._my_map['learningObjectiveIds'] = \

--- a/dlkit/records/adaptive/multi_choice_questions/randomized_questions.py
+++ b/dlkit/records/adaptive/multi_choice_questions/randomized_questions.py
@@ -134,15 +134,18 @@ class MultiChoiceRandomizeChoicesQuestionFormRecord(MultiChoiceTextAndFilesQuest
     ]
 
     def __init__(self, **kwargs):
-        super(MultiChoiceRandomizeChoicesQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceRandomizeChoicesQuestionFormRecord, self).__init__(**kwargs)
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiChoiceRandomizeChoicesQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceRandomizeChoicesQuestionFormRecord, self)._init_map(**kwargs)
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiChoiceRandomizeChoicesQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceRandomizeChoicesQuestionFormRecord, self)._init_metadata(**kwargs)
 
 
 class MultiChoiceRandomizeChoicesQuestionRecord(MultiChoiceTextAndFilesQuestionRecord):

--- a/dlkit/records/assessment/analytic/irt.py
+++ b/dlkit/records/assessment/analytic/irt.py
@@ -29,7 +29,8 @@ class ItemDecimalValuesFormRecord(DecimalValuesFormRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(ItemDecimalValuesFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ItemDecimalValuesFormRecord, self).__init__(**kwargs)
 
 
 class IRTItemRecord(DecimalValuesRecord):
@@ -84,11 +85,13 @@ class IRTItemFormRecord(ItemDecimalValuesFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(IRTItemFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(IRTItemFormRecord, self).__init__(**kwargs)
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(IRTItemFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(IRTItemFormRecord, self)._init_map(**kwargs)
         self._my_map['decimalValues']['difficulty'] = \
             self._decimal_value_metadata['default_decimal_values'][1]
         self._my_map['decimalValues']['discrimination'] = \

--- a/dlkit/records/assessment/basic/assessment_records.py
+++ b/dlkit/records/assessment/basic/assessment_records.py
@@ -106,7 +106,8 @@ class ReviewOptionsAssessmentOfferedFormRecord(abc_assessment_records.Assessment
     ]
 
     def __init__(self, **kwargs):
-        super(ReviewOptionsAssessmentOfferedFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ReviewOptionsAssessmentOfferedFormRecord, self).__init__(**kwargs)
         self._review_options_metadata = None
         self._whether_correct_metadata = None
         self._solutions_metadata = None
@@ -120,7 +121,8 @@ class ReviewOptionsAssessmentOfferedFormRecord(abc_assessment_records.Assessment
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(ReviewOptionsAssessmentOfferedFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ReviewOptionsAssessmentOfferedFormRecord, self)._init_map(**kwargs)
         self._my_map['reviewOptions'] = \
             dict(self._review_options_metadata['default_object_values'][0])
         self._my_map['reviewOptions']['whetherCorrect'] = \
@@ -149,7 +151,8 @@ class ReviewOptionsAssessmentOfferedFormRecord(abc_assessment_records.Assessment
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(ReviewOptionsAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ReviewOptionsAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
         self._review_options_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -426,4 +429,5 @@ class ReviewOptionsAssessmentTakenFormRecord(abc_assessment_records.AssessmentTa
     ]
 
     def __init__(self, **kwargs):
-        super(ReviewOptionsAssessmentTakenFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ReviewOptionsAssessmentTakenFormRecord, self).__init__(**kwargs)

--- a/dlkit/records/assessment/basic/base_records.py
+++ b/dlkit/records/assessment/basic/base_records.py
@@ -138,20 +138,23 @@ class ItemWithSolutionRecord(ObjectInitRecord):
 
 class ItemWithSolutionFormRecord(osid_records.OsidRecord):
     def __init__(self, **kwargs):
-        super(ItemWithSolutionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ItemWithSolutionFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._solution_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(ItemWithSolutionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ItemWithSolutionFormRecord, self)._init_map(**kwargs)
         self._my_map['solution'] = \
             dict(self._solution_metadata['default_string_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(ItemWithSolutionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ItemWithSolutionFormRecord, self)._init_metadata(**kwargs)
         self._solution_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -230,18 +233,21 @@ class MultiLanguageQuestionRecord(MultiLanguageUtils,
 class MultiLanguageQuestionFormRecord(MultiLanguageUtils,
                                       osid_records.OsidRecord):
     def __init__(self, **kwargs):
-        super(MultiLanguageQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQuestionFormRecord, self).__init__(**kwargs)
         self._texts_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['texts'] = \
             self._texts_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQuestionFormRecord, self)._init_metadata(**kwargs)
         self._texts_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/drag_and_drop_records.py
+++ b/dlkit/records/assessment/basic/drag_and_drop_records.py
@@ -290,14 +290,16 @@ class DragAndDropAnswerFormRecord(osid_records.OsidRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(DragAndDropAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(DragAndDropAnswerFormRecord, self).__init__(**kwargs)
         self._zone_conditions_metadata = None
         self._coordinate_conditions_metadata = None
         self._spatial_unit_conditions_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(DragAndDropAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(DragAndDropAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['zoneConditions'] = \
             self._zone_conditions_metadata['default_object_values'][0]
         self._my_map['coordinateConditions'] = \
@@ -307,7 +309,8 @@ class DragAndDropAnswerFormRecord(osid_records.OsidRecord,
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(DragAndDropAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(DragAndDropAnswerFormRecord, self)._init_metadata(**kwargs)
         self._zone_conditions_metadata = {
             'zone_matches': Id(self._authority,
                                self._namespace,
@@ -598,7 +601,8 @@ class MultiLanguageDragAndDropQuestionFormRecord(MultiLanguageQuestionFormRecord
     """
 
     def __init__(self, **kwargs):
-        super(MultiLanguageDragAndDropQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageDragAndDropQuestionFormRecord, self).__init__(**kwargs)
         self._droppables_metadata = None
         self._targets_metadata = None
         self._zones_metadata = None
@@ -608,7 +612,8 @@ class MultiLanguageDragAndDropQuestionFormRecord(MultiLanguageQuestionFormRecord
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageDragAndDropQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageDragAndDropQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['droppables'] = \
             self._droppables_metadata['default_object_values'][0]
         self._my_map['targets'] = \
@@ -624,7 +629,8 @@ class MultiLanguageDragAndDropQuestionFormRecord(MultiLanguageQuestionFormRecord
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageDragAndDropQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageDragAndDropQuestionFormRecord, self)._init_metadata(**kwargs)
         self._droppables_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/feedback_answer_records.py
+++ b/dlkit/records/assessment/basic/feedback_answer_records.py
@@ -67,7 +67,8 @@ class FeedbackAnswerFormRecord(osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(FeedbackAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(FeedbackAnswerFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._confused_learning_objectives_metadata = None
@@ -75,7 +76,8 @@ class FeedbackAnswerFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(FeedbackAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(FeedbackAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['confusedLearningObjectiveIds'] = \
             self._confused_learning_objectives_metadata['default_list_values'][0]
         self._my_map['feedback'] = \
@@ -83,7 +85,8 @@ class FeedbackAnswerFormRecord(osid_records.OsidRecord):
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(FeedbackAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(FeedbackAnswerFormRecord, self)._init_metadata(**kwargs)
         self._confused_learning_objectives_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -181,19 +184,22 @@ class MultiLanguageFeedbacksAnswerRecord(MultiLanguageUtils,
 class MultiLanguageFeedbacksAnswerFormRecord(MultiLanguageUtils,
                                              osid_records.OsidRecord):
     def __init__(self, **kwargs):
-        super(MultiLanguageFeedbacksAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFeedbacksAnswerFormRecord, self).__init__(**kwargs)
         self._confused_learning_objectives_metadata = None
         self._feedbacks_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageFeedbacksAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFeedbacksAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['feedbacks'] = \
             self._feedbacks_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageFeedbacksAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFeedbacksAnswerFormRecord, self)._init_metadata(**kwargs)
         self._confused_learning_objectives_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/multi_choice_records.py
+++ b/dlkit/records/assessment/basic/multi_choice_records.py
@@ -731,21 +731,20 @@ class MultiLanguageMultipleChoiceQuestionRecord(MultiLanguageQuestionRecord):
 
 class MultiLanguageMultipleChoiceQuestionFormRecord(MultiLanguageQuestionFormRecord):
     def __init__(self, **kwargs):
-        if not self._block_super(kwargs):
-            super(MultiLanguageMultipleChoiceQuestionFormRecord, self).__init__(**kwargs)
+        # Do NOT call "self._block_super()" for these methods, because we want to ALWAYS
+        #   call the inherited initers.
+        super(MultiLanguageMultipleChoiceQuestionFormRecord, self).__init__(**kwargs)
         self._choices_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        if not self._block_super(kwargs):
-            super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_map(**kwargs)
+        super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['choices'] = \
             self._choices_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        if not self._block_super(kwargs):
-            super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
+        super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choices_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/multi_choice_records.py
+++ b/dlkit/records/assessment/basic/multi_choice_records.py
@@ -75,20 +75,23 @@ class BaseMultiChoiceQuestionFormRecord(osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(BaseMultiChoiceQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceQuestionFormRecord, self).__init__(**kwargs)
         self._choices_metadata = None
         self._choice_name_metadata = None
         self._multi_answer_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(BaseMultiChoiceQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['choices'] = []
         self._my_map['multiAnswer'] = False
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(BaseMultiChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choices_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -182,12 +185,14 @@ class BaseMultiChoiceTextQuestionFormRecord(BaseMultiChoiceQuestionFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(BaseMultiChoiceTextQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceTextQuestionFormRecord, self).__init__(**kwargs)
         self._choice_text_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(BaseMultiChoiceTextQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceTextQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choice_text_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -290,12 +295,14 @@ class BaseMultiChoiceFileQuestionFormRecord(BaseMultiChoiceQuestionFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(BaseMultiChoiceFileQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceFileQuestionFormRecord, self).__init__(**kwargs)
         self._choice_file_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(BaseMultiChoiceFileQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseMultiChoiceFileQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choice_file_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -535,19 +542,22 @@ class MultiChoiceAnswerFormRecord(osid_records.OsidRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(MultiChoiceAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceAnswerFormRecord, self).__init__(**kwargs)
         self._choice_ids_metadata = None
         self._choice_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiChoiceAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['choiceIds'] = \
             self._choice_ids_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiChoiceAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiChoiceAnswerFormRecord, self)._init_metadata(**kwargs)
         self._choice_ids_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -721,18 +731,21 @@ class MultiLanguageMultipleChoiceQuestionRecord(MultiLanguageQuestionRecord):
 
 class MultiLanguageMultipleChoiceQuestionFormRecord(MultiLanguageQuestionFormRecord):
     def __init__(self, **kwargs):
-        super(MultiLanguageMultipleChoiceQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageMultipleChoiceQuestionFormRecord, self).__init__(**kwargs)
         self._choices_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['choices'] = \
             self._choices_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageMultipleChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choices_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/simple_records.py
+++ b/dlkit/records/assessment/basic/simple_records.py
@@ -198,6 +198,8 @@ class TextAnswerFormRecord(TextFormRecord, abc_assessment_records.AnswerFormReco
     ]
 
     def __init__(self, **kwargs):
+        if not self._block_super(kwargs):
+            super(TextAnswerFormRecord, self).__init__(**kwargs)
         if self.is_for_update():
             self._min_string_length = self._my_map['minStringLength']
             self._max_string_length = self._my_map['maxStringLength']
@@ -206,18 +208,20 @@ class TextAnswerFormRecord(TextFormRecord, abc_assessment_records.AnswerFormReco
             self._max_string_length_metadata = None
             self._min_string_length = None
             self._max_string_length = None
-        super(TextAnswerFormRecord, self).__init__(**kwargs)
 
     def _init_map(self, **kwargs):
         """stub"""
+        if not self._block_super(kwargs):
+            super(TextAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['minStringLength'] = \
             self._min_string_length_metadata['default_cardinal_values'][0]
         self._my_map['maxStringLength'] = \
             self._max_string_length_metadata['default_cardinal_values'][0]
-        super(TextAnswerFormRecord, self)._init_map(**kwargs)
 
     def _init_metadata(self, **kwargs):
         """stub"""
+        if not self._block_super(kwargs):
+            super(TextAnswerFormRecord, self)._init_metadata(**kwargs)
         self._min_string_length_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -250,7 +254,6 @@ class TextAnswerFormRecord(TextFormRecord, abc_assessment_records.AnswerFormReco
             'maximum_cardinal': None,
             'cardinal_set': []
         }
-        super(TextAnswerFormRecord, self)._init_metadata(**kwargs)
 
     def get_min_string_length_metadata(self):
         """stub"""
@@ -341,7 +344,8 @@ class TextsAnswerFormRecord(TextsFormRecord, abc_assessment_records.AnswerFormRe
     ]
 
     def __init__(self, **kwargs):
-        super(TextsAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsAnswerFormRecord, self).__init__(**kwargs)
         if self.is_for_update():
             self._min_string_length = \
                 self._my_map.get('minStringLength',
@@ -357,7 +361,8 @@ class TextsAnswerFormRecord(TextsFormRecord, abc_assessment_records.AnswerFormRe
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(TextsAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['minStringLength'] = \
             self._min_string_length_metadata['default_cardinal_values'][0]
         self._my_map['maxStringLength'] = \
@@ -365,7 +370,8 @@ class TextsAnswerFormRecord(TextsFormRecord, abc_assessment_records.AnswerFormRe
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(TextsAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsAnswerFormRecord, self)._init_metadata(**kwargs)
         self._min_string_length_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/basic/text_answer_records.py
+++ b/dlkit/records/assessment/basic/text_answer_records.py
@@ -48,7 +48,8 @@ class ShortTextAnswerFormRecord(TextAnswerFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(ShortTextAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ShortTextAnswerFormRecord, self).__init__(**kwargs)
         # Need to call this method after __init__ so that it doesn't get over-written to the default
         self.set_max_string_length(128)
 
@@ -92,7 +93,8 @@ class ShortTextAnswersFormRecord(TextsAnswerFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(ShortTextAnswersFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ShortTextAnswersFormRecord, self).__init__(**kwargs)
         # Need to call this method after __init__ so that it doesn't get over-written to the default
         self.set_max_string_length(128)
 
@@ -134,6 +136,7 @@ class ExtendedTextAnswerFormRecord(TextAnswerFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(ExtendedTextAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ExtendedTextAnswerFormRecord, self).__init__(**kwargs)
         # Need to call this method after __init__ so that it doesn't get over-written to the default
         self.set_max_string_length(None)

--- a/dlkit/records/assessment/clix/assessment_offered_records.py
+++ b/dlkit/records/assessment/clix/assessment_offered_records.py
@@ -42,18 +42,21 @@ class NofMAssessmentOfferedFormRecord(osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(NofMAssessmentOfferedFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(NofMAssessmentOfferedFormRecord, self).__init__(**kwargs)
         self._n_of_m_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(NofMAssessmentOfferedFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(NofMAssessmentOfferedFormRecord, self)._init_map(**kwargs)
         self._my_map['nOfM'] = \
             int(self._n_of_m_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(NofMAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(NofMAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
         self._n_of_m_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -133,20 +136,23 @@ class UnlockPreviousButtonAssessmentOfferedFormRecord(osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(UnlockPreviousButtonAssessmentOfferedFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(UnlockPreviousButtonAssessmentOfferedFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._unlock_previous_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(UnlockPreviousButtonAssessmentOfferedFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(UnlockPreviousButtonAssessmentOfferedFormRecord, self)._init_map(**kwargs)
         self._my_map['unlockPrevious'] = \
             str(self._unlock_previous_metadata['default_string_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(UnlockPreviousButtonAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(UnlockPreviousButtonAssessmentOfferedFormRecord, self)._init_metadata(**kwargs)
         self._unlock_previous_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/edx/drag_and_drop_records.py
+++ b/dlkit/records/assessment/edx/drag_and_drop_records.py
@@ -64,7 +64,8 @@ class EdXDragAndDropQuestionFormRecord(edXItemFormRecord,
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(EdXDragAndDropQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(EdXDragAndDropQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['text']['text'] = ''
 
 

--- a/dlkit/records/assessment/edx/multi_choice_records.py
+++ b/dlkit/records/assessment/edx/multi_choice_records.py
@@ -41,7 +41,8 @@ class edXMultiChoiceQuestionRecord(MultiChoiceTextQuestionRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(edXMultiChoiceQuestionRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXMultiChoiceQuestionRecord, self).__init__(**kwargs)
 
         # change my_map
         if ('rerandomize' in self._my_map and
@@ -90,18 +91,21 @@ class edXMultiChoiceQuestionFormRecord(QuestionTextAndFilesMixin,
     ]
 
     def __init__(self, **kwargs):
-        super(edXMultiChoiceQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXMultiChoiceQuestionFormRecord, self).__init__(**kwargs)
         self._rerandomize_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(edXMultiChoiceQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXMultiChoiceQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['rerandomize'] = \
             self._rerandomize_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(edXMultiChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXMultiChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
         self._rerandomize_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/edx/numeric_response_records.py
+++ b/dlkit/records/assessment/edx/numeric_response_records.py
@@ -155,7 +155,8 @@ class edXNumericResponseQuestionFormRecord(edXItemFormRecord,
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(edXNumericResponseQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXNumericResponseQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['text']['text'] = ''
 
 

--- a/dlkit/records/assessment/fbw/assessment_bank_records.py
+++ b/dlkit/records/assessment/fbw/assessment_bank_records.py
@@ -33,18 +33,21 @@ class AssessmentBankWithObjectiveBankFormRecord(ObjectInitRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(AssessmentBankWithObjectiveBankFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentBankWithObjectiveBankFormRecord, self).__init__(**kwargs)
         self._objective_bank_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(AssessmentBankWithObjectiveBankFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentBankWithObjectiveBankFormRecord, self)._init_map(**kwargs)
         self._my_map['objectiveBankId'] = \
             self._objective_bank_id_metadata['default_id_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(AssessmentBankWithObjectiveBankFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentBankWithObjectiveBankFormRecord, self)._init_metadata(**kwargs)
         self._objective_bank_id_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/fbw/assessment_part_records.py
+++ b/dlkit/records/assessment/fbw/assessment_part_records.py
@@ -33,13 +33,15 @@ class AssessmentPartWithLearningObjectiveFormRecord(ObjectInitRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(AssessmentPartWithLearningObjectiveFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentPartWithLearningObjectiveFormRecord, self).__init__(**kwargs)
         self._learning_objective_id_metadata = None
         self._minimum_proficiency_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(AssessmentPartWithLearningObjectiveFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentPartWithLearningObjectiveFormRecord, self)._init_map(**kwargs)
         self._my_map['learningObjectiveId'] = \
             str(self._learning_objective_id_metadata['default_id_values'][0])
         self._my_map['minimumProficiency'] = \
@@ -47,7 +49,8 @@ class AssessmentPartWithLearningObjectiveFormRecord(ObjectInitRecord):
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(AssessmentPartWithLearningObjectiveFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentPartWithLearningObjectiveFormRecord, self)._init_metadata(**kwargs)
         self._learning_objective_id_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/fbw/assessment_records.py
+++ b/dlkit/records/assessment/fbw/assessment_records.py
@@ -29,18 +29,21 @@ class AssessmentWithFollowOnPhaseFormRecord(ObjectInitRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(AssessmentWithFollowOnPhaseFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentWithFollowOnPhaseFormRecord, self).__init__(**kwargs)
         self._follow_on_phase_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(AssessmentWithFollowOnPhaseFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentWithFollowOnPhaseFormRecord, self)._init_map(**kwargs)
         self._my_map['hasSpawnedFollowOnPhase'] = \
             bool(self._follow_on_phase_metadata['default_boolean_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(AssessmentWithFollowOnPhaseFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssessmentWithFollowOnPhaseFormRecord, self)._init_metadata(**kwargs)
         self._follow_on_phase_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -89,18 +92,21 @@ class GeneratedAssessmentFormRecord(ObjectInitRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(GeneratedAssessmentFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(GeneratedAssessmentFormRecord, self).__init__(**kwargs)
         self._source_assessment_taken_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(GeneratedAssessmentFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(GeneratedAssessmentFormRecord, self)._init_map(**kwargs)
         self._my_map['sourceAssessmentTakenId'] = \
             str(self._source_assessment_taken_id_metadata['default_id_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(GeneratedAssessmentFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(GeneratedAssessmentFormRecord, self)._init_metadata(**kwargs)
         self._source_assessment_taken_id_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/mecqbank/mecqbank_base_records.py
+++ b/dlkit/records/assessment/mecqbank/mecqbank_base_records.py
@@ -89,12 +89,14 @@ class PDFPreviewFormRecord(FilesFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(PDFPreviewFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(PDFPreviewFormRecord, self).__init__(**kwargs)
         self._preview_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(PDFPreviewFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(PDFPreviewFormRecord, self)._init_metadata(**kwargs)
         self._preview_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -174,20 +176,23 @@ class SimpleDifficultyItemFormRecord(TextsFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(SimpleDifficultyItemFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(SimpleDifficultyItemFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._difficulty_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(SimpleDifficultyItemFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(SimpleDifficultyItemFormRecord, self)._init_map(**kwargs)
         self._my_map['texts']['difficulty'] = \
             self._difficulty_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(SimpleDifficultyItemFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(SimpleDifficultyItemFormRecord, self)._init_metadata(**kwargs)
         self._difficulty_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -270,20 +275,23 @@ class SourceItemFormRecord(TextsFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(SourceItemFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceItemFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._source_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(SourceItemFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceItemFormRecord, self)._init_map(**kwargs)
         self._my_map['texts']['source'] = \
             self._source_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(SourceItemFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceItemFormRecord, self)._init_metadata(**kwargs)
         self._source_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -359,18 +367,21 @@ class PublishedFormRecord(osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(PublishedFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(PublishedFormRecord, self).__init__(**kwargs)
         self._published_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(PublishedFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(PublishedFormRecord, self)._init_map(**kwargs)
         self._my_map['published'] = \
             self._published_metadata['default_published_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(PublishedFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(PublishedFormRecord, self)._init_metadata(**kwargs)
         self._published_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/orthographic_visualization/orthographic_records.py
+++ b/dlkit/records/assessment/orthographic_visualization/orthographic_records.py
@@ -45,18 +45,21 @@ class FirstAngleProjectionFormRecord(ObjectInitRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(FirstAngleProjectionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(FirstAngleProjectionFormRecord, self).__init__(**kwargs)
         self._first_angle_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(FirstAngleProjectionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(FirstAngleProjectionFormRecord, self)._init_map(**kwargs)
         self._my_map['firstAngle'] = \
             self._first_angle_metadata['default_boolean_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(FirstAngleProjectionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(FirstAngleProjectionFormRecord, self)._init_metadata(**kwargs)
         self._first_angle_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -184,12 +187,14 @@ class BaseOrthoQuestionFormRecord(BaseInitMixin):
     ]
 
     def __init__(self, **kwargs):
-        super(BaseOrthoQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseOrthoQuestionFormRecord, self).__init__(**kwargs)
         self._ortho_view_set_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(BaseOrthoQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(BaseOrthoQuestionFormRecord, self)._init_metadata(**kwargs)
         self._ortho_view_set_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -427,12 +432,14 @@ class LabelOrthoFacesAnswerFormRecord(IntegerAnswersFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(LabelOrthoFacesAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(LabelOrthoFacesAnswerFormRecord, self).__init__(**kwargs)
         self._face_values_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(LabelOrthoFacesAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(LabelOrthoFacesAnswerFormRecord, self)._init_metadata(**kwargs)
         self._face_values_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -522,12 +529,14 @@ class EulerRotationAnswerFormRecord(IntegerAnswersFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(EulerRotationAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(EulerRotationAnswerFormRecord, self).__init__(**kwargs)
         self._euler_rotation_metadata = None
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(EulerRotationAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(EulerRotationAnswerFormRecord, self)._init_metadata(**kwargs)
         self._euler_rotation_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/qti/basic.py
+++ b/dlkit/records/assessment/qti/basic.py
@@ -394,7 +394,7 @@ class QTIQuestionRecord(QTITypeRecordMixin, ObjectInitRecord):
             choice_interaction['responseIdentifier'] = 'RESPONSE_1'
             choice_interaction['shuffle'] = self.shuffle
             if str(self.genus_type) in [str(CHOICE_INTERACTION_QUESTION_GENUS),
-                                                       str(CHOICE_INTERACTION_SURVEY_QUESTION_GENUS)]:
+                                        str(CHOICE_INTERACTION_SURVEY_QUESTION_GENUS)]:
                 choice_interaction['maxChoices'] = '1'
             else:
                 choice_interaction['maxChoices'] = '0'
@@ -496,7 +496,7 @@ class QTIQuestionRecord(QTITypeRecordMixin, ObjectInitRecord):
                     choice_text = self._wrap_xml(choice['text'], 'simpleChoice')
                 else:
                     choice_text = self._wrap_xml(self.get_matching_language_value('texts',
-                                                                                                 dictionary=choice).text,
+                                                                                  dictionary=choice).text,
                                                  'simpleChoice')
                 choice_tag = BeautifulSoup(choice_text, 'xml').simpleChoice
                 choice_tag['identifier'] = choice['id']
@@ -581,7 +581,7 @@ class QTIQuestionRecord(QTITypeRecordMixin, ObjectInitRecord):
                         choice_text = self._wrap_xml(choice['text'], 'inlineChoice')
                     else:
                         choice_text = self._wrap_xml(self.get_matching_language_value('texts',
-                                                                                                     dictionary=choice).text,
+                                                                                      dictionary=choice).text,
                                                      'inlineChoice')
 
                     inline_choice = BeautifulSoup(choice_text, 'xml').inlineChoice

--- a/dlkit/records/assessment/qti/basic.py
+++ b/dlkit/records/assessment/qti/basic.py
@@ -654,18 +654,21 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(QTIQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIQuestionFormRecord, self).__init__(**kwargs)
         self._shuffle_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(QTIQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['shuffle'] = \
             bool(self._shuffle_metadata['default_boolean_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(QTIQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIQuestionFormRecord, self)._init_metadata(**kwargs)
         self._shuffle_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/qti/basic.py
+++ b/dlkit/records/assessment/qti/basic.py
@@ -214,9 +214,9 @@ class QTIFormWithMediaFiles(object):
         media_file_elements += media_file_data_elements
         if len(media_file_elements) > 0 and media_files is not None:
             if 'Question' in self._namespace:
-                self.get_question_form_record(FILES_QUESTION_RECORD)
+                self.add_form_record(FILES_QUESTION_RECORD)
             else:
-                self.get_answer_form_record(FILES_ANSWER_RECORD)
+                self.add_form_record(FILES_ANSWER_RECORD)
 
             for media_file_element in media_file_elements:
                 if 'src' in media_file_element.attrs:
@@ -237,12 +237,12 @@ class QTIFormWithMediaFiles(object):
                 # they are all unique from Onyx...
                 if media_file_name in media_files:
                     self.add_file(DataInputStream(media_files[media_file_name]),
-                                                      label=media_file_name,
-                                                      asset_type=asset_type,
-                                                      asset_content_type=ac_genus_type,
-                                                      asset_content_record_types=[MULTI_LANGUAGE_ASSET_CONTENTS],
-                                                      asset_name=media_file_id,
-                                                      asset_description='QTI media file')
+                                                  label=media_file_name,
+                                                  asset_type=asset_type,
+                                                  asset_content_type=ac_genus_type,
+                                                  asset_content_record_types=[MULTI_LANGUAGE_ASSET_CONTENTS],
+                                                  asset_name=media_file_id,
+                                                  asset_description='QTI media file')
 
                     media_file_element[key] = 'AssetContent:{0}'.format(media_file_name)
 
@@ -251,48 +251,48 @@ class QTITypeRecordMixin(object):
     """Helper mixing to detect item / question type based on genusTypeId"""
     def _is_multiple_choice(self):
         return str(self.genus_type) in [str(CHOICE_INTERACTION_QUESTION_GENUS),
-                                                       str(CHOICE_INTERACTION_MULTI_QUESTION_GENUS),
-                                                       str(CHOICE_INTERACTION_GENUS),
-                                                       str(CHOICE_INTERACTION_MULTI_GENUS)]
+                                        str(CHOICE_INTERACTION_MULTI_QUESTION_GENUS),
+                                        str(CHOICE_INTERACTION_GENUS),
+                                        str(CHOICE_INTERACTION_MULTI_GENUS)]
 
     def _is_reflection(self):
         return str(self.genus_type) in [str(CHOICE_INTERACTION_SURVEY_GENUS),
-                                                       str(CHOICE_INTERACTION_MULTI_SELECT_SURVEY_GENUS),
-                                                       str(CHOICE_INTERACTION_SURVEY_QUESTION_GENUS),
-                                                       str(CHOICE_INTERACTION_MULTI_SELECT_SURVEY_QUESTION_GENUS)]
+                                        str(CHOICE_INTERACTION_MULTI_SELECT_SURVEY_GENUS),
+                                        str(CHOICE_INTERACTION_SURVEY_QUESTION_GENUS),
+                                        str(CHOICE_INTERACTION_MULTI_SELECT_SURVEY_QUESTION_GENUS)]
 
     def _is_file_upload(self):
         return str(self.genus_type) in [str(UPLOAD_INTERACTION_GENERIC_GENUS),
-                                                       str(UPLOAD_INTERACTION_GENERIC_QUESTION_GENUS)]
+                                        str(UPLOAD_INTERACTION_GENERIC_QUESTION_GENUS)]
 
     def _is_audio_record(self):
         # excludes MW sandbox
         return str(self.genus_type) in [str(UPLOAD_INTERACTION_AUDIO_QUESTION_GENUS),
-                                                       str(UPLOAD_INTERACTION_AUDIO_GENUS)]
+                                        str(UPLOAD_INTERACTION_AUDIO_GENUS)]
 
     def _is_image_sequence(self):
         return str(self.genus_type) in [str(ORDER_INTERACTION_OBJECT_MANIPULATION_GENUS),
-                                                       str(ORDER_INTERACTION_OBJECT_MANIPULATION_QUESTION_GENUS)]
+                                        str(ORDER_INTERACTION_OBJECT_MANIPULATION_QUESTION_GENUS)]
 
     def _is_mw_sentence(self):
         return str(self.genus_type) in [str(ORDER_INTERACTION_MW_SENTENCE_QUESTION_GENUS),
-                                                       str(ORDER_INTERACTION_MW_SENTENCE_GENUS)]
+                                        str(ORDER_INTERACTION_MW_SENTENCE_GENUS)]
 
     def _is_mw_sandbox(self):
         return str(self.genus_type) in [str(ORDER_INTERACTION_MW_SANDBOX_GENUS),
-                                                       str(ORDER_INTERACTION_MW_SANDBOX_QUESTION_GENUS)]
+                                        str(ORDER_INTERACTION_MW_SANDBOX_QUESTION_GENUS)]
 
     def _is_fitb(self):
         return str(self.genus_type) in [str(INLINE_CHOICE_MW_FITB_INTERACTION_QUESTION_GENUS),
-                                                       str(INLINE_CHOICE_MW_FITB_INTERACTION_GENUS)]
+                                        str(INLINE_CHOICE_MW_FITB_INTERACTION_GENUS)]
 
     def _is_numeric_response(self):
         return str(self.genus_type) in [str(NUMERIC_RESPONSE_QUESTION_GENUS),
-                                                       str(NUMERIC_RESPONSE_GENUS)]
+                                        str(NUMERIC_RESPONSE_GENUS)]
 
     def _is_short_answer(self):
         return str(self.genus_type) in [str(EXTENDED_TEXT_INTERACTION_QUESTION_GENUS),
-                                                       str(EXTENDED_TEXT_INTERACTION_GENUS)]
+                                        str(EXTENDED_TEXT_INTERACTION_GENUS)]
 
     def _only_generic_right_feedback(self):
         return (self._is_file_upload() or
@@ -829,7 +829,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 interaction = soup.itemBody.orderInteraction
             if ('shuffle' not in interaction.attrs or
                     json.loads(interaction['shuffle'])):
-                self.get_question_form_record(RANDOMIZED_MULTI_CHOICE_QUESTION_RECORD)
+                self.add_form_record(RANDOMIZED_MULTI_CHOICE_QUESTION_RECORD)
                 self.set_shuffle(True)
             else:
                 self.set_shuffle(False)
@@ -855,7 +855,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
         description = create_display_text(item_name, language_code)
 
         if soup.itemBody.choiceInteraction:
-            self.get_question_form_record(MULTI_LANGUAGE_MULTIPLE_CHOICE_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_MULTIPLE_CHOICE_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -867,7 +867,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
             choice_interaction = soup.itemBody.choiceInteraction.extract()
 
             self.add_text(create_display_text(_stringify(soup.itemBody),
-                                                                  language_code))
+                                              language_code))
             for choice in choice_interaction.find_all('simpleChoice'):
                 choice_text = create_display_text(_stringify(choice),
                                                   language_code)
@@ -886,7 +886,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                     self.set_genus_type(CHOICE_INTERACTION_MULTI_QUESTION_GENUS)
 
         elif soup.itemBody.uploadInteraction:
-            self.get_question_form_record(MULTI_LANGUAGE_FILE_UPLOAD_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_FILE_UPLOAD_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -897,7 +897,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 self.add_description(description)  # Is there a description in QTI?
             upload_interaction = soup.itemBody.uploadInteraction.extract()
             self.add_text(create_display_text(_stringify(soup.itemBody),
-                                                                  language_code))
+                                              language_code))
             # now check the keywords for the specific upload type
             # out of band agreement
             if len(keywords) > 0 and 'audiort' in [k.lower() for k in keywords]:
@@ -907,7 +907,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
         elif soup.itemBody.orderInteraction:
             # the main difference here (MW Sentence) will be that
             # the answer has multiple choices used, not a single choice
-            self.get_question_form_record(MULTI_LANGUAGE_ORDERED_CHOICE_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_ORDERED_CHOICE_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -918,7 +918,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 self.add_description(description)  # Is there a description in QTI?
             order_interaction = soup.itemBody.orderInteraction.extract()
             self.add_text(create_display_text(_stringify(soup.itemBody),
-                                                                  language_code))
+                                              language_code))
 
             is_object_manipulation = False
             if len(keywords) > 0 and 'mwsentence' in [k.lower() for k in keywords]:
@@ -941,7 +941,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
         elif soup.itemBody.extendedTextInteraction:
             # do the multi language one second so that the texts fields and metadata
             # do not get wiped out
-            self.get_question_form_record(MULTI_LANGUAGE_EXTENDED_TEXT_INTERACTION_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_EXTENDED_TEXT_INTERACTION_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -952,7 +952,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 self.add_description(description)  # Is there a description in QTI?
             text_interaction = soup.itemBody.extendedTextInteraction.extract()
             self.add_text(create_display_text(_stringify(soup.itemBody),
-                                                                  language_code))
+                                              language_code))
 
             # capture the metadata values for extended text interaction
             if 'maxStrings' in text_interaction.attrs:
@@ -963,7 +963,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 self.set_expected_lines(int(text_interaction['expectedLines']))
             self.set_genus_type(EXTENDED_TEXT_INTERACTION_QUESTION_GENUS)
         elif soup.itemBody.inlineChoiceInteraction:
-            self.get_question_form_record(MULTI_LANGUAGE_INLINE_CHOICE_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_INLINE_CHOICE_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -982,18 +982,18 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                     choice_text = create_display_text(str(choice),
                                                       language_code)
                     self.add_choice(choice_text,
-                                                        region_identifier,
-                                                        identifier=choice['identifier'])
+                                    region_identifier,
+                                    identifier=choice['identifier'])
                     choice.extract()
 
             # now try to wrap the words in the itemBody ...
             self._recursively_wrap_words_in_item_body(soup.itemBody)
 
             self.add_text(create_display_text(_stringify(soup.itemBody),
-                                                                  language_code))
+                                                         language_code))
             self.set_genus_type(INLINE_CHOICE_MW_FITB_INTERACTION_QUESTION_GENUS)
         elif soup.itemBody.textEntryInteraction and soup.templateDeclaration:
-            self.get_question_form_record(MULTI_LANGUAGE_NUMERIC_RESPONSE_QUESTION_RECORD)
+            self.add_form_record(MULTI_LANGUAGE_NUMERIC_RESPONSE_QUESTION_RECORD)
             try:
                 self.add_display_name(display_name)
             except AttributeError:
@@ -1026,7 +1026,7 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
             self.set_expression(expression)
 
             self.add_text(create_display_text(original_item_body,
-                                                                  language_code))
+                                              language_code))
 
             variables = {}
             for var in soup.find_all('templateDeclaration'):
@@ -1062,11 +1062,11 @@ class QTIQuestionFormRecord(QTIFormWithMediaFiles, osid_records.OsidRecord):
                 else:
                     step = 1
                 self.add_variable(var_name.lower(),  # why does it lowercase? see the simple_numeric_response_test_file
-                                                      var_data['type'],
-                                                      var_data['min'],
-                                                      var_data['max'],
-                                                      var_step=step,
-                                                      format=var_format)
+                                  var_data['type'],
+                                  var_data['min'],
+                                  var_data['max'],
+                                  var_step=step,
+                                  format=var_format)
         else:
             raise OperationFailed('Item type not supported or unrecognized')
 

--- a/dlkit/records/assessment/qti/extended_text_interaction.py
+++ b/dlkit/records/assessment/qti/extended_text_interaction.py
@@ -19,14 +19,16 @@ class QTIExtendedTextAnswerQuestionFormRecord(ExtendedTextAnswerQuestionFormReco
     ]
 
     def __init__(self, **kwargs):
-        super(QTIExtendedTextAnswerQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIExtendedTextAnswerQuestionFormRecord, self).__init__(**kwargs)
         self._max_strings_metadata = None
         self._expected_length_metadata = None
         self._expected_lines_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(QTIExtendedTextAnswerQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIExtendedTextAnswerQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['maxStrings'] = \
             self._max_strings_metadata['default_integer_values'][0]
         self._my_map['expectedLength'] = \
@@ -36,7 +38,8 @@ class QTIExtendedTextAnswerQuestionFormRecord(ExtendedTextAnswerQuestionFormReco
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(QTIExtendedTextAnswerQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(QTIExtendedTextAnswerQuestionFormRecord, self)._init_metadata(**kwargs)
         self._max_strings_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -194,14 +197,16 @@ class MultiLanguageQTIExtendedTextAnswerQuestionFormRecord(MultiLanguageQuestion
     ]
 
     def __init__(self, **kwargs):
-        super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self).__init__(**kwargs)
         self._max_strings_metadata = None
         self._expected_lines_metadata = None
         self._expected_length_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['maxStrings'] = \
             self._max_strings_metadata['default_integer_values'][0]
         self._my_map['expectedLength'] = \
@@ -211,7 +216,8 @@ class MultiLanguageQTIExtendedTextAnswerQuestionFormRecord(MultiLanguageQuestion
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageQTIExtendedTextAnswerQuestionFormRecord, self)._init_metadata(**kwargs)
         self._max_strings_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/qti/inline_choice_records.py
+++ b/dlkit/records/assessment/qti/inline_choice_records.py
@@ -234,19 +234,22 @@ class InlineChoiceTextQuestionFormRecord(QuestionTextFormRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(InlineChoiceTextQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceTextQuestionFormRecord, self).__init__(**kwargs)
         self._choices_metadata = None
         self._choice_text_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(InlineChoiceTextQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceTextQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['choices'] = \
             self._choices_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(InlineChoiceTextQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceTextQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choices_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -450,20 +453,23 @@ class InlineChoiceFeedbackAndFilesAnswerFormRecord(FilesAnswerFormRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
         self._inline_regions_metadata = None
         self._choice_ids_metadata = None
         self._choice_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['inlineRegions'] = \
             self._inline_regions_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
         self._inline_regions_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -580,19 +586,22 @@ class MultiLanguageInlineChoiceQuestionFormRecord(MultiLanguageQuestionFormRecor
     ]
 
     def __init__(self, **kwargs):
-        super(MultiLanguageInlineChoiceQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageInlineChoiceQuestionFormRecord, self).__init__(**kwargs)
         self._choices_metadata = None
         self._choice_text_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageInlineChoiceQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageInlineChoiceQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['choices'] = \
             self._choices_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageInlineChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageInlineChoiceQuestionFormRecord, self)._init_metadata(**kwargs)
         self._choices_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -894,20 +903,23 @@ class InlineChoiceAnswerFormRecord(osid_records.OsidRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(InlineChoiceAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceAnswerFormRecord, self).__init__(**kwargs)
         self._inline_regions_metadata = None
         self._choice_ids_metadata = None
         self._choice_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(InlineChoiceAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['inlineRegions'] = \
             self._inline_regions_metadata['default_object_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(InlineChoiceAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(InlineChoiceAnswerFormRecord, self)._init_metadata(**kwargs)
         self._inline_regions_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/assessment/qti/numeric_response_records.py
+++ b/dlkit/records/assessment/qti/numeric_response_records.py
@@ -362,13 +362,15 @@ class CalculationInteractionQuestionFormRecord(QuestionTextFormRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(CalculationInteractionQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionQuestionFormRecord, self).__init__(**kwargs)
         self._variables_metadata = None
         self._expression_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(CalculationInteractionQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['text']['text'] = ''
         self._my_map['variables'] = \
             self._variables_metadata['default_object_values'][0]
@@ -377,7 +379,8 @@ class CalculationInteractionQuestionFormRecord(QuestionTextFormRecord,
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(CalculationInteractionQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionQuestionFormRecord, self)._init_metadata(**kwargs)
         self._variables_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -534,18 +537,21 @@ class CalculationInteractionFeedbackAndFilesAnswerFormRecord(DecimalValuesFormRe
     ]
 
     def __init__(self, **kwargs):
-        super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
         self._tolerance_mode_metadata = None
 
     def _init_map(self, **kwargs):
         """call these all manually because non-cooperative"""
-        super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['toleranceMode'] = \
             self._tolerance_mode_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(CalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
         self._tolerance_mode_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -680,13 +686,15 @@ class MultiLanguageCalculationInteractionQuestionFormRecord(MultiLanguageQuestio
     ]
 
     def __init__(self, **kwargs):
-        super(MultiLanguageCalculationInteractionQuestionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionQuestionFormRecord, self).__init__(**kwargs)
         self._variables_metadata = None
         self._expression_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(MultiLanguageCalculationInteractionQuestionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionQuestionFormRecord, self)._init_map(**kwargs)
         self._my_map['variables'] = \
             self._variables_metadata['default_object_values'][0]
         self._my_map['expression'] = \
@@ -694,7 +702,8 @@ class MultiLanguageCalculationInteractionQuestionFormRecord(MultiLanguageQuestio
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageCalculationInteractionQuestionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionQuestionFormRecord, self)._init_metadata(**kwargs)
         self._variables_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -845,18 +854,21 @@ class MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord(Decima
     ]
 
     def __init__(self, **kwargs):
-        super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self).__init__(**kwargs)
         self._tolerance_mode_metadata = None
 
     def _init_map(self, **kwargs):
         """call these all manually because non-cooperative"""
-        super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_map(**kwargs)
         self._my_map['toleranceMode'] = \
             self._tolerance_mode_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageCalculationInteractionFeedbackAndFilesAnswerFormRecord, self)._init_metadata(**kwargs)
         self._tolerance_mode_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/osid/base_records.py
+++ b/dlkit/records/osid/base_records.py
@@ -489,12 +489,14 @@ class ProvenanceFormRecord(osid_records.OsidRecord):
     """form to create / update a record's provenance itemId"""
 
     def __init__(self, **kwargs):
-        super(ProvenanceFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ProvenanceFormRecord, self).__init__(**kwargs)
         self._provenance_metadata = None
 
     def _init_metadata(self, **kwargs):
         """initializes form metadata for this record"""
-        super(ProvenanceFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ProvenanceFormRecord, self)._init_metadata(**kwargs)
         self._provenance_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -514,7 +516,8 @@ class ProvenanceFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """initializes form map for this record"""
-        super(ProvenanceFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ProvenanceFormRecord, self)._init_map(**kwargs)
         self._my_map['provenanceId'] = \
             self._provenance_metadata['default_object_values'][0]
         if not self.is_for_update():
@@ -570,18 +573,21 @@ class ResourceFormRecord(osid_records.OsidRecord):
     """basic form record"""
 
     def __init__(self, **kwargs):
-        super(ResourceFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ResourceFormRecord, self).__init__(**kwargs)
         self._resource_id_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(ResourceFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ResourceFormRecord, self)._init_map(**kwargs)
         self._my_map['resourceId'] = \
             self._resource_id_metadata['default_id_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(ResourceFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ResourceFormRecord, self)._init_metadata(**kwargs)
         self._resource_id_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -643,20 +649,23 @@ class TextFormRecord(osid_records.OsidRecord):
     """form to create / update the text value"""
 
     def __init__(self, **kwargs):
-        super(TextFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._text_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(TextFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextFormRecord, self)._init_map(**kwargs)
         self._my_map['text'] = \
             dict(self._text_metadata['default_string_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(TextFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextFormRecord, self)._init_metadata(**kwargs)
         self._text_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -726,20 +735,23 @@ class IntegerValueFormRecord(osid_records.OsidRecord):
     """form to create / update an integer value"""
 
     def __init__(self, **kwargs):
-        super(IntegerValueFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValueFormRecord, self).__init__(**kwargs)
         self._min_integer_value = None
         self._max_integer_value = None
         self._integer_value_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(IntegerValueFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValueFormRecord, self)._init_map(**kwargs)
         self._my_map['integerValue'] = \
             self._integer_value_metadata['default_integer_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(IntegerValueFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValueFormRecord, self)._init_map(**kwargs)
         self._integer_value_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -804,20 +816,23 @@ class DecimalValueFormRecord(osid_records.OsidRecord):
     """form to create / update a decimal value"""
 
     def __init__(self, **kwargs):
-        super(DecimalValueFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValueFormRecord, self).__init__(**kwargs)
         self._min_decimal_value = None
         self._max_decimal_value = None
         self._decimal_value_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(DecimalValueFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValueFormRecord, self)._init_map(**kwargs)
         self._my_map['decimalValue'] = \
             self._decimal_value_metadata['default_decimal_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(DecimalValueFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValueFormRecord, self)._init_metadata(**kwargs)
         self._decimal_value_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -896,7 +911,8 @@ class TextsFormRecord(osid_records.OsidRecord):
     """form to create / update text values"""
 
     def __init__(self, **kwargs):
-        super(TextsFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsFormRecord, self).__init__(**kwargs)
         self._min_string_length = None
         self._max_string_length = None
         self._texts_metadata = None
@@ -905,13 +921,15 @@ class TextsFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(TextsFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsFormRecord, self)._init_map(**kwargs)
         self._my_map['texts'] = \
             dict(self._texts_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(TextsFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TextsFormRecord, self)._init_metadata(**kwargs)
         self._texts_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -1050,7 +1068,8 @@ class IntegerValuesFormRecord(osid_records.OsidRecord):
     """form for create / update of multiple integer values"""
 
     def __init__(self, **kwargs):
-        super(IntegerValuesFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValuesFormRecord, self).__init__(**kwargs)
         self._min_integer_value = None
         self._max_integer_value = None
         self._integer_value_metadata = None
@@ -1059,13 +1078,15 @@ class IntegerValuesFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(IntegerValuesFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValuesFormRecord, self)._init_map(**kwargs)
         self._my_map['integerValues'] = \
             dict(self._integer_values_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(IntegerValuesFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(IntegerValuesFormRecord, self)._init_metadata(**kwargs)
         self._integer_values_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -1187,7 +1208,8 @@ class DecimalValuesFormRecord(osid_records.OsidRecord):
     """form for create / update of multiple decimal values"""
 
     def __init__(self, **kwargs):
-        super(DecimalValuesFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValuesFormRecord, self).__init__(**kwargs)
         self._min_decimal_value = None
         self._max_decimal_value = None
         self._decimal_value_metadata = None
@@ -1196,13 +1218,15 @@ class DecimalValuesFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(DecimalValuesFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValuesFormRecord, self)._init_map(**kwargs)
         self._my_map['decimalValues'] = \
             dict(self._decimal_values_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(DecimalValuesFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(DecimalValuesFormRecord, self)._init_metadata(**kwargs)
         self._decimal_values_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -1357,7 +1381,8 @@ class edXBaseFormRecord(osid_records.OsidRecord):
     """form for create / update of edX metadata fields"""
 
     def __init__(self, **kwargs):
-        super(edXBaseFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXBaseFormRecord, self).__init__(**kwargs)
         self._attempts_metadata = None
         self._showanswer_metadata = None
         self._markdown_metadata = None
@@ -1365,7 +1390,8 @@ class edXBaseFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(edXBaseFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXBaseFormRecord, self)._init_map(**kwargs)
         self._my_map['attempts'] = \
             int(self._attempts_metadata['default_object_values'][0])
         self._my_map['weight'] = \
@@ -1379,7 +1405,8 @@ class edXBaseFormRecord(osid_records.OsidRecord):
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(edXBaseFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXBaseFormRecord, self)._init_metadata(**kwargs)
         self._attempts_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -1582,20 +1609,23 @@ class TimeValueFormRecord(osid_records.OsidRecord):
     """form to create / update the time value"""
 
     def __init__(self, **kwargs):
-        super(TimeValueFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeValueFormRecord, self).__init__(**kwargs)
         self._min_time_value = None
         self._max_time_value = None
         self._time_value_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(TimeValueFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeValueFormRecord, self)._init_map(**kwargs)
         self._my_map['timeValue'] = \
             dict(self._time_value_metadata['default_duration_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(TimeValueFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeValueFormRecord, self)._init_metadata(**kwargs)
         self._time_value_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -1906,20 +1936,23 @@ class FilesFormRecord(osid_records.OsidRecord, AssetUtils):
     """form to create / update attached files"""
 
     def __init__(self, **kwargs):
-        super(FilesFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(FilesFormRecord, self).__init__(**kwargs)
         self._files_metadata = None
         self._file_metadata = None
         self._label_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(FilesFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(FilesFormRecord, self)._init_map(**kwargs)
         self._my_map['fileIds'] = \
             dict(self._files_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(FilesFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(FilesFormRecord, self)._init_metadata(**kwargs)
         self._files_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -2157,18 +2190,21 @@ class FileFormRecord(osid_records.OsidRecord, AssetUtils):
     """form for create / update of a single file"""
 
     def __init__(self, **kwargs):
-        super(FileFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(FileFormRecord, self).__init__(**kwargs)
         self._file_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(FileFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(FileFormRecord, self)._init_map(**kwargs)
         self._my_map['fileId'] = \
             dict(self._file_metadata['default_object_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(FileFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(FileFormRecord, self)._init_metadata(**kwargs)
         self._file_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -2300,20 +2336,23 @@ class ColorCoordinateFormRecord(osid_records.OsidRecord):
     """form to create / update the color of an object"""
 
     def __init__(self, **kwargs):
-        super(ColorCoordinateFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(ColorCoordinateFormRecord, self).__init__(**kwargs)
         self._min_decimal_value = None
         self._max_decimal_value = None
         self._color_coordinate_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(ColorCoordinateFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(ColorCoordinateFormRecord, self)._init_map(**kwargs)
         self._my_map['colorCoordinate'] = \
             dict(self._color_coordinate_metadata['default_coordinate_values'][0])
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(ColorCoordinateFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(ColorCoordinateFormRecord, self)._init_metadata(**kwargs)
         self._color_coordinate_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -2362,13 +2401,15 @@ class ColorCoordinateFormRecord(osid_records.OsidRecord):
 class TemporalFormRecord(osid_records.OsidRecord):
     """This form is used to create and update temporals."""
     def __init__(self, **kwargs):
-        super(TemporalFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TemporalFormRecord, self).__init__(**kwargs)
         self._start_date_metadata = None
         self._end_date_metadata = None
 
     def _init_metadata(self, **kwargs):
         # pylint: disable=attribute-defined-outside-init
-        super(TemporalFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TemporalFormRecord, self)._init_metadata(**kwargs)
         self._start_date_metadata = {
             'element_id': Id(authority=self._authority,
                              namespace=self._namespace,
@@ -2387,7 +2428,8 @@ class TemporalFormRecord(osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         # pylint: disable=attribute-defined-outside-init
-        super(TemporalFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TemporalFormRecord, self)._init_map(**kwargs)
         default_start_date = self._start_date_metadata['default_date_time_values'][0]
         self._my_map['startDate'] = DateTime(year=default_start_date.year,
                                                                  month=default_start_date.month,
@@ -2582,7 +2624,8 @@ class SourceableFormRecord(osid_records.OsidRecord):
     """
 
     def __init__(self, **kwargs):
-        super(SourceableFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceableFormRecord, self).__init__(**kwargs)
         self._provider_metadata = None
         self._provider_default = None
         self._branding_default = None
@@ -2591,7 +2634,8 @@ class SourceableFormRecord(osid_records.OsidRecord):
         self._license_metadata = None
 
     def _init_metadata(self, **kwargs):
-        super(SourceableFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceableFormRecord, self)._init_metadata(**kwargs)
         self._provider_metadata = {
             'element_id': Id(authority=self._authority,
                              namespace=self._namespace,
@@ -2614,7 +2658,8 @@ class SourceableFormRecord(osid_records.OsidRecord):
         self._license_default = dict(self._license_metadata['default_string_values'][0])
 
     def _init_map(self, **kwargs):
-        super(SourceableFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(SourceableFormRecord, self)._init_map(**kwargs)
         if 'effective_agent_id' in kwargs:
             try:
                 mgr = self._get_provider_manager('RESOURCE', local=True)
@@ -2877,12 +2922,14 @@ class MultiLanguageFormRecord(MultiLanguageUtils,
     """
 
     def __init__(self, **kwargs):
-        super(MultiLanguageFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFormRecord, self).__init__(**kwargs)
         self._display_names_metadata = None
         self._descriptions_metadata = None
 
     def _init_metadata(self, **kwargs):
-        super(MultiLanguageFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFormRecord, self)._init_metadata(**kwargs)
         self._display_names_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -2913,7 +2960,8 @@ class MultiLanguageFormRecord(MultiLanguageUtils,
         }
 
     def _init_map(self, **kwargs):
-        super(MultiLanguageFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(MultiLanguageFormRecord, self)._init_map(**kwargs)
         self._my_map['displayNames'] = self._display_names_metadata['default_object_values'][0]
         self._my_map['descriptions'] = self._descriptions_metadata['default_object_values'][0]
 

--- a/dlkit/records/osid/object_records.py
+++ b/dlkit/records/osid/object_records.py
@@ -182,12 +182,14 @@ class EnclosureQueryRecord(QueryInitRecord):
 class EnclosureFormRecord(ProvenanceFormRecord, osid_records.OsidRecord):
 
     def __init__(self, **kwargs):
-        super(EnclosureFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(EnclosureFormRecord, self).__init__(**kwargs)
         self._enclosed_object_metadata = None
 
     def _init_metadata(self, **kwargs):
         """Initialize metadata for this record"""
-        super(EnclosureFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(EnclosureFormRecord, self)._init_metadata(**kwargs)
         self._enclosed_object_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -205,7 +207,8 @@ class EnclosureFormRecord(ProvenanceFormRecord, osid_records.OsidRecord):
 
     def _init_map(self, **kwargs):
         """Initialize osid objects _my_map for this record"""
-        super(EnclosureFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(EnclosureFormRecord, self)._init_map(**kwargs)
         self._my_map['enclosedObjectId'] = \
             self._enclosed_object_metadata['default_id_values'][0]
 

--- a/dlkit/records/repository/basic/media_accessibility.py
+++ b/dlkit/records/repository/basic/media_accessibility.py
@@ -42,11 +42,13 @@ class AssetContentMultiLanguageAltTextFormRecord(MultiLanguageUtils, osid_record
     ]
 
     def __init__(self, **kwargs):
-        super(AssetContentMultiLanguageAltTextFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageAltTextFormRecord, self).__init__(**kwargs)
         self._alt_texts_metadata = None
 
     def _init_metadata(self, **kwargs):
-        super(AssetContentMultiLanguageAltTextFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageAltTextFormRecord, self)._init_metadata(**kwargs)
         self._alt_texts_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -63,7 +65,8 @@ class AssetContentMultiLanguageAltTextFormRecord(MultiLanguageUtils, osid_record
         }
 
     def _init_map(self, **kwargs):
-        super(AssetContentMultiLanguageAltTextFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageAltTextFormRecord, self)._init_map(**kwargs)
         self._my_map['altTexts'] = self._alt_texts_metadata['default_object_values'][0]
 
     def get_alt_texts_metadata(self):
@@ -155,11 +158,13 @@ class AssetContentMultiLanguageMediaDescriptionFormRecord(MultiLanguageUtils, os
     ]
 
     def __init__(self, **kwargs):
-        super(AssetContentMultiLanguageMediaDescriptionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageMediaDescriptionFormRecord, self).__init__(**kwargs)
         self._media_descriptions_metadata = None
 
     def _init_metadata(self, **kwargs):
-        super(AssetContentMultiLanguageMediaDescriptionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageMediaDescriptionFormRecord, self)._init_metadata(**kwargs)
         self._media_descriptions_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -176,7 +181,8 @@ class AssetContentMultiLanguageMediaDescriptionFormRecord(MultiLanguageUtils, os
         }
 
     def _init_map(self, **kwargs):
-        super(AssetContentMultiLanguageMediaDescriptionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(AssetContentMultiLanguageMediaDescriptionFormRecord, self)._init_map(**kwargs)
         self._my_map['mediaDescriptions'] = self._media_descriptions_metadata['default_object_values'][0]
 
     def get_media_descriptions_metadata(self):

--- a/dlkit/records/repository/edx/compositions.py
+++ b/dlkit/records/repository/edx/compositions.py
@@ -63,26 +63,25 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
     ]
 
     def __init__(self, **kwargs):
-        if not self._block_super(kwargs):
-            super(EdXCompositionFormRecord, self).__init__(**kwargs)
+        # Do NOT call "self._block_super()" for these methods, because we want to ALWAYS
+        #   call the inherited initers.
+        super(EdXCompositionFormRecord, self).__init__(**kwargs)
         self._visible_to_students_metadata = None
         self._draft_metadata = None
         self._learning_objective_ids_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        if not self._block_super(kwargs):
-            super(EdXCompositionFormRecord, self)._init_map(**kwargs)
+        super(EdXCompositionFormRecord, self)._init_map(**kwargs)
 
-        if hasattr(self, '_text_metadata'):
-            self._my_map['texts']['fileName'] = \
-                self._text_metadata['default_string_values'][0]
-            self._my_map['texts']['format'] = \
-                self._text_metadata['default_string_values'][0]  # homework, exam, lab, etc.
-            self._my_map['texts']['userPartitionId'] = \
-                self._text_metadata['default_string_values'][0]
-            self._my_map['texts']['org'] = \
-                self._text_metadata['default_string_values'][0]
+        self._my_map['texts']['fileName'] = \
+            self._text_metadata['default_string_values'][0]
+        self._my_map['texts']['format'] = \
+            self._text_metadata['default_string_values'][0]  # homework, exam, lab, etc.
+        self._my_map['texts']['userPartitionId'] = \
+            self._text_metadata['default_string_values'][0]
+        self._my_map['texts']['org'] = \
+            self._text_metadata['default_string_values'][0]
 
         self._my_map['visibleToStudents'] = \
             self._visible_to_students_metadata['default_boolean_values'][0]
@@ -93,8 +92,7 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        if not self._block_super(kwargs):
-            super(EdXCompositionFormRecord, self)._init_metadata(**kwargs)
+        super(EdXCompositionFormRecord, self)._init_metadata(**kwargs)
         self._visible_to_students_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/dlkit/records/repository/edx/compositions.py
+++ b/dlkit/records/repository/edx/compositions.py
@@ -65,6 +65,7 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
     def __init__(self, **kwargs):
         # Do NOT call "self._block_super()" for these methods, because we want to ALWAYS
         #   call the inherited initers.
+        kwargs['block_super'] = False
         super(EdXCompositionFormRecord, self).__init__(**kwargs)
         self._visible_to_students_metadata = None
         self._draft_metadata = None
@@ -72,6 +73,7 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
 
     def _init_map(self, **kwargs):
         """stub"""
+        kwargs['block_super'] = False
         super(EdXCompositionFormRecord, self)._init_map(**kwargs)
 
         self._my_map['texts']['fileName'] = \
@@ -92,6 +94,7 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
 
     def _init_metadata(self, **kwargs):
         """stub"""
+        kwargs['block_super'] = False
         super(EdXCompositionFormRecord, self)._init_metadata(**kwargs)
         self._visible_to_students_metadata = {
             'element_id': Id(self._authority,

--- a/dlkit/records/repository/edx/compositions.py
+++ b/dlkit/records/repository/edx/compositions.py
@@ -63,33 +63,38 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
     ]
 
     def __init__(self, **kwargs):
-        super(EdXCompositionFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(EdXCompositionFormRecord, self).__init__(**kwargs)
         self._visible_to_students_metadata = None
         self._draft_metadata = None
         self._learning_objective_ids_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(EdXCompositionFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(EdXCompositionFormRecord, self)._init_map(**kwargs)
 
-        self._my_map['texts']['fileName'] = \
-            self._text_metadata['default_string_values'][0]
-        self._my_map['texts']['format'] = \
-            self._text_metadata['default_string_values'][0]  # homework, exam, lab, etc.
+        if hasattr(self, '_text_metadata'):
+            self._my_map['texts']['fileName'] = \
+                self._text_metadata['default_string_values'][0]
+            self._my_map['texts']['format'] = \
+                self._text_metadata['default_string_values'][0]  # homework, exam, lab, etc.
+            self._my_map['texts']['userPartitionId'] = \
+                self._text_metadata['default_string_values'][0]
+            self._my_map['texts']['org'] = \
+                self._text_metadata['default_string_values'][0]
+
         self._my_map['visibleToStudents'] = \
             self._visible_to_students_metadata['default_boolean_values'][0]
         self._my_map['draft'] = \
             self._draft_metadata['default_boolean_values'][0]
-        self._my_map['texts']['userPartitionId'] = \
-            self._text_metadata['default_string_values'][0]
-        self._my_map['texts']['org'] = \
-            self._text_metadata['default_string_values'][0]
         self._my_map['learningObjectiveIds'] = \
             self._learning_objective_ids_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(EdXCompositionFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(EdXCompositionFormRecord, self)._init_metadata(**kwargs)
         self._visible_to_students_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,
@@ -130,8 +135,8 @@ class EdXCompositionFormRecord(TemporalFormRecord, TextsFormRecord, ProvenanceFo
             'array': True,
             'default_string_values': [[]],
             'syntax': 'STRING',
-            'minimum_string_length': self._min_string_length,
-            'maximum_string_length': self._max_string_length,
+            'minimum_string_length': self._min_string_length if hasattr(self, '_min_string_length') else None,
+            'maximum_string_length': self._max_string_length if hasattr(self, '_max_string_length') else None,
             'string_set': []
         }
 

--- a/dlkit/records/repository/edx/edx_assets.py
+++ b/dlkit/records/repository/edx/edx_assets.py
@@ -292,17 +292,20 @@ class edXAssetFormRecord(TextsFormRecord, ProvenanceFormRecord):
     ]
 
     def __init__(self, **kwargs):
-        super(edXAssetFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXAssetFormRecord, self).__init__(**kwargs)
         self._learning_objective_ids_metadata = None
 
     def _init_map(self, **kwargs):
-        super(edXAssetFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXAssetFormRecord, self)._init_map(**kwargs)
 
         self._my_map['learningObjectiveIds'] = \
             self._learning_objective_ids_metadata['default_string_values'][0]
 
     def _init_metadata(self, **kwargs):
-        super(edXAssetFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(edXAssetFormRecord, self)._init_metadata(**kwargs)
 
         # ideally this would be type LIST?
         self._learning_objective_ids_metadata = {

--- a/dlkit/records/repository/vcb/vcb_records.py
+++ b/dlkit/records/repository/vcb/vcb_records.py
@@ -52,13 +52,15 @@ class TimeStampFormRecord(abc_repository_records.AssetContentFormRecord,
     ]
 
     def __init__(self, **kwargs):
-        super(TimeStampFormRecord, self).__init__(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeStampFormRecord, self).__init__(**kwargs)
         self._start_timestamp_metadata = None
         self._end_timestamp_metadata = None
 
     def _init_map(self, **kwargs):
         """stub"""
-        super(TimeStampFormRecord, self)._init_map(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeStampFormRecord, self)._init_map(**kwargs)
         self._my_map['startTimestamp'] = \
             self._start_timestamp_metadata['default_integer_values'][0]
         self._my_map['endTimestamp'] = \
@@ -66,7 +68,8 @@ class TimeStampFormRecord(abc_repository_records.AssetContentFormRecord,
 
     def _init_metadata(self, **kwargs):
         """stub"""
-        super(TimeStampFormRecord, self)._init_metadata(**kwargs)
+        if not self._block_super(kwargs):
+            super(TimeStampFormRecord, self)._init_metadata(**kwargs)
         self._start_timestamp_metadata = {
             'element_id': Id(self._authority,
                              self._namespace,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 
 [pytest]
 # addopts = --pep8 --pylint --cov . --cov-config .coveragerc --cov-report term --cov-report html
-addopts = --pep8 --cov . --cov-config .coveragerc --cov-report term --cov-report html -p no:warnings
+addopts = --pep8 --cov . --cov-config .coveragerc --cov-report html -p no:warnings
 pep8ignore =
   *.py E501
 

--- a/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
+++ b/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
@@ -1,0 +1,49 @@
+import unittest
+
+from copy import deepcopy
+
+from dlkit.abstract_osid.osid import errors
+from dlkit.json_ import utilities as dlkit_utilities
+from dlkit.json_.osid.metadata import Metadata
+from dlkit.json_.osid.objects import OsidObject, OsidObjectForm
+from dlkit.records.adaptive.multi_choice_questions.randomized_questions import *
+
+from ... import utilities
+
+
+class TestMultiChoiceRandomizeChoicesQuestionFormRecord(unittest.TestCase):
+    """Tests for MultiChoiceRandomizeChoicesQuestionFormRecord"""
+    def setUp(self):
+        self.osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        self.osid_object_form._authority = 'TESTING.MIT.EDU'
+        self.osid_object_form._namespace = 'records.Testing'
+
+    def test_block_super_prevents_calling_initer(self):
+        self.osid_object_form._min_string_length = 255
+        form = utilities.add_class(self.osid_object_form,
+                                   MultiChoiceRandomizeChoicesQuestionFormRecord,
+                                   initialize=True)
+        self.assertEqual(form._min_string_length, 255)
+
+    def test_block_super_prevents_calling_init_metadata(self):
+        self.osid_object_form._text_metadata = 'foo'
+        form = utilities.add_class(self.osid_object_form,
+                                   MultiChoiceRandomizeChoicesQuestionFormRecord,
+                                   initialize=True)
+        self.assertEqual(form._text_metadata, 'foo')
+
+    def test_block_super_prevents_calling_init_map(self):
+        self.osid_object_form._my_map['fileIds'] = {
+            'label': {
+                'assetContentId': '123'
+            }
+        }
+        form = utilities.add_class(self.osid_object_form,
+                                   MultiChoiceRandomizeChoicesQuestionFormRecord,
+                                   initialize=True)
+        self.assertEqual(form._my_map['fileIds'],
+                         {
+            'label': {
+                'assetContentId': '123'
+            }
+        })

--- a/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
+++ b/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
@@ -3,7 +3,7 @@ import unittest
 from dlkit.json_.osid.objects import OsidObject, OsidObjectForm
 from dlkit.records.adaptive.multi_choice_questions.randomized_questions import *
 
-from dlkit.tests.records import utilities
+from ... import utilities
 
 
 class TestMultiChoiceRandomizeChoicesQuestionFormRecord(unittest.TestCase):

--- a/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
+++ b/tests/records/adaptive/multi_choice_questions/test_randomized_questions.py
@@ -1,14 +1,9 @@
 import unittest
 
-from copy import deepcopy
-
-from dlkit.abstract_osid.osid import errors
-from dlkit.json_ import utilities as dlkit_utilities
-from dlkit.json_.osid.metadata import Metadata
 from dlkit.json_.osid.objects import OsidObject, OsidObjectForm
 from dlkit.records.adaptive.multi_choice_questions.randomized_questions import *
 
-from ... import utilities
+from dlkit.tests.records import utilities
 
 
 class TestMultiChoiceRandomizeChoicesQuestionFormRecord(unittest.TestCase):

--- a/tests/records/repository/edx/test_compositions.py
+++ b/tests/records/repository/edx/test_compositions.py
@@ -114,8 +114,7 @@ def edx_composition_form_test_fixture(request):
     request.cls.osid_object_form._namespace = 'records.Testing'
     request.cls.form = utilities.add_class(request.cls.osid_object_form,
                                            EdXCompositionFormRecord,
-                                           initialize=True,
-                                           block_super=False)
+                                           initialize=True)
     request.cls.form._my_map = deepcopy(COMPOSITION_STAMP)
 
 
@@ -125,8 +124,7 @@ def get_edx_composition_form():
     osid_object_form._namespace = 'records.Testing'
     form = utilities.add_class(osid_object_form,
                                EdXCompositionFormRecord,
-                               initialize=True,
-                               block_super=False)
+                               initialize=True)
     form._my_map.update(deepcopy(COMPOSITION_STAMP))
     return form
 
@@ -298,7 +296,7 @@ class TestEdXCompositionFormRecord(object):
             form.clear_learning_objective_ids()
             assert form._my_map['learningObjectiveIds'] == []
 
-    def test_block_super_prevents_calling_initer(self):
+    def test_block_super_never_invoked_for_initer(self):
         osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
         osid_object_form._authority = 'TESTING.MIT.EDU'
         osid_object_form._namespace = 'records.Testing'
@@ -307,19 +305,19 @@ class TestEdXCompositionFormRecord(object):
         form = utilities.add_class(osid_object_form,
                                    EdXCompositionFormRecord,
                                    initialize=True)
-        assert form._min_string_length == 255
-        assert form._max_string_length == 255
+        assert form._min_string_length is None
+        assert form._max_string_length is None
 
-    def test_block_super_prevents_calling_init_metadata(self):
+    def test_block_super_never_invoked_for_init_metadata(self):
         osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
         osid_object_form._authority = 'TESTING.MIT.EDU'
         osid_object_form._namespace = 'records.Testing'
         form = utilities.add_class(osid_object_form,
                                    EdXCompositionFormRecord,
                                    initialize=True)
-        assert not hasattr(form, '_text_metadata')
+        assert hasattr(form, '_text_metadata')
 
-    def test_block_super_prevents_calling_init_map(self):
+    def test_block_super_never_invoked_for_init_map(self):
         osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
         osid_object_form._authority = 'TESTING.MIT.EDU'
         osid_object_form._namespace = 'records.Testing'
@@ -331,7 +329,7 @@ class TestEdXCompositionFormRecord(object):
         form = utilities.add_class(osid_object_form,
                                    EdXCompositionFormRecord,
                                    initialize=True)
-        assert form._my_map['texts'] == {
+        assert not form._my_map['texts'] == {
             'label': {
                 'text': 'foo'
             }

--- a/tests/records/repository/edx/test_compositions.py
+++ b/tests/records/repository/edx/test_compositions.py
@@ -112,7 +112,10 @@ def edx_composition_form_test_fixture(request):
     request.cls.osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
     request.cls.osid_object_form._authority = 'TESTING.MIT.EDU'
     request.cls.osid_object_form._namespace = 'records.Testing'
-    request.cls.form = utilities.add_class(request.cls.osid_object_form, EdXCompositionFormRecord, initialize=True)
+    request.cls.form = utilities.add_class(request.cls.osid_object_form,
+                                           EdXCompositionFormRecord,
+                                           initialize=True,
+                                           block_super=False)
     request.cls.form._my_map = deepcopy(COMPOSITION_STAMP)
 
 
@@ -120,7 +123,10 @@ def get_edx_composition_form():
     osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
     osid_object_form._authority = 'TESTING.MIT.EDU'
     osid_object_form._namespace = 'records.Testing'
-    form = utilities.add_class(osid_object_form, EdXCompositionFormRecord, initialize=True)
+    form = utilities.add_class(osid_object_form,
+                               EdXCompositionFormRecord,
+                               initialize=True,
+                               block_super=False)
     form._my_map.update(deepcopy(COMPOSITION_STAMP))
     return form
 
@@ -291,6 +297,45 @@ class TestEdXCompositionFormRecord(object):
             assert form._my_map['learningObjectiveIds'] == ['1', '2', '3']
             form.clear_learning_objective_ids()
             assert form._my_map['learningObjectiveIds'] == []
+
+    def test_block_super_prevents_calling_initer(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        osid_object_form._min_string_length = 255
+        osid_object_form._max_string_length = 255
+        form = utilities.add_class(osid_object_form,
+                                   EdXCompositionFormRecord,
+                                   initialize=True)
+        assert form._min_string_length == 255
+        assert form._max_string_length == 255
+
+    def test_block_super_prevents_calling_init_metadata(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        form = utilities.add_class(osid_object_form,
+                                   EdXCompositionFormRecord,
+                                   initialize=True)
+        assert not hasattr(form, '_text_metadata')
+
+    def test_block_super_prevents_calling_init_map(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        osid_object_form._my_map['texts'] = {
+            'label': {
+                'text': 'foo'
+            }
+        }
+        form = utilities.add_class(osid_object_form,
+                                   EdXCompositionFormRecord,
+                                   initialize=True)
+        assert form._my_map['texts'] == {
+            'label': {
+                'text': 'foo'
+            }
+        }
 
 
 class QueryWrapper(OsidObjectQuery):
@@ -1078,3 +1123,38 @@ class TestEdXCourseRunCompositionFormRecord(object):
     def test_clearing_grading_policy_before_set_raises_not_found(self):
         with pytest.raises(errors.NotFound):
             self.form.clear_grading_policy()
+
+    def test_block_super_still_calls_initer_of_texts_superclass(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        osid_object_form._min_string_length = 255
+        osid_object_form._max_string_length = 255
+        form = utilities.add_class(osid_object_form,
+                                   EdXCourseRunCompositionFormRecord,
+                                   initialize=True)
+        assert form._min_string_length is None
+        assert form._max_string_length is None
+
+    def test_block_super_still_calls_init_metadata_of_texts_superclass(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        form = utilities.add_class(osid_object_form,
+                                   EdXCourseRunCompositionFormRecord,
+                                   initialize=True)
+        assert hasattr(form, '_text_metadata')
+
+    def test_block_super_still_calls_init_map_of_texts_superclass(self):
+        osid_object_form = OsidObjectForm(object_name='TEST_OBJECT')
+        osid_object_form._authority = 'TESTING.MIT.EDU'
+        osid_object_form._namespace = 'records.Testing'
+        osid_object_form._my_map['texts'] = {
+            'label': {
+                'text': 'foo'
+            }
+        }
+        form = utilities.add_class(osid_object_form,
+                                   EdXCourseRunCompositionFormRecord,
+                                   initialize=True)
+        assert form._my_map['texts'] == {}

--- a/tests/records/test_general_records_behavior.py
+++ b/tests/records/test_general_records_behavior.py
@@ -15,6 +15,7 @@ from dlkit.runtime.proxy_example import SimpleRequest
 
 ITEM_FORM_WITH_SOLUTION = Type(**registry.ITEM_RECORD_TYPES['with-solution'])
 PROVENANCE_ITEM = Type(**registry.ITEM_RECORD_TYPES['provenance'])
+MULTI_CHOICE_RANDOMIZED_QUESTION = Type(**registry.QUESTION_RECORD_TYPES['multi-choice-randomized'])
 
 
 def get_assessment_manager():
@@ -135,3 +136,65 @@ class TestUpdateObjectMapCalled(unittest.TestCase):
 
     def test_first_record_should_be_called(self):
         self.assertTrue(isinstance(self.item_1.object_map['creationTime'], dict))
+
+
+class TestAddFormRecord(unittest.TestCase):
+    """ This is to make sure that ``add_form_record()`` passes the ``block_super`` argument,
+        at least for the tested records. Each record should have its own unit test for this argument, too. """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mgr = get_assessment_manager()
+        form = cls.mgr.get_bank_form_for_create([])
+        form.display_name = 'Bank for testing'
+        cls.bank = cls.mgr.create_bank(form)
+
+    def setUp(self):
+        self.test_display_name = 'my test item'
+        form = self.bank.get_item_form_for_create([])
+        form.display_name = self.test_display_name
+        self.item_1 = self.bank.create_item(form)
+
+    @classmethod
+    def tearDownClass(cls):
+        for assessment in cls.bank.get_assessments():
+            for assessment_offered in cls.bank.get_assessments_offered_for_assessment(assessment.ident):
+                for assessment_taken in cls.bank.get_assessments_taken_for_assessment_offered(assessment_offered.ident):
+                    cls.bank.delete_assessment_taken(assessment_taken.ident)
+                cls.bank.delete_assessment_offered(assessment_offered.ident)
+            cls.bank.delete_assessment(assessment.ident)
+        for item in cls.bank.get_items():
+            cls.bank.delete_item(item.ident)
+        cls.mgr.delete_bank(cls.bank.ident)
+
+    def tearDown(self):
+        for item in self.bank.get_items():
+            self.bank.delete_item(item.ident)
+
+    def test_block_super_prevents_calling_initer(self):
+        form = self.bank.get_item_form_for_update(self.item_1.ident)
+        form._min_string_length = 255
+        form.add_form_record(MULTI_CHOICE_RANDOMIZED_QUESTION)
+        self.assertEqual(form._min_string_length, 255)
+
+    def test_block_super_prevents_calling_init_metadata(self):
+        form = self.bank.get_item_form_for_update(self.item_1.ident)
+        form._text_metadata = 'foo'
+        form.add_form_record(MULTI_CHOICE_RANDOMIZED_QUESTION)
+        self.assertEqual(form._text_metadata, 'foo')
+
+    def test_block_super_prevents_calling_init_map(self):
+        form = self.bank.get_item_form_for_update(self.item_1.ident)
+
+        form._my_map['fileIds'] = {
+            'label': {
+                'assetContentId': '123'
+            }
+        }
+        form.add_form_record(MULTI_CHOICE_RANDOMIZED_QUESTION)
+        self.assertEqual(form._my_map['fileIds'],
+                         {
+            'label': {
+                'assetContentId': '123'
+            }
+        })

--- a/tests/records/utilities.py
+++ b/tests/records/utilities.py
@@ -31,16 +31,12 @@ TEST_OBJECT_MAP = {
 }
 
 
-def add_class(original_object, new_class, initialize=False, block_super=True):
+def add_class(original_object, new_class, initialize=False):
     """The records tests require that we instantiate simple objects for each record class. With the current
         record schema, where we modify the object's __class__.__bases__ instead of using .my_osid_object,
         this helper method takes care of adding the new record.
 
-    initialize = Optional flag to run init_metadata and init_map
-    block_super = Optional flag to control init behavior. Typically don't need to provide a value, except for
-                    tests where you are adding a class that subclasses other classes you want initialized. i.e.
-                    edX Composition tests.
-    """
+    initialize = Optional flag to run init_metadata and init_map"""
     object_name = original_object._namespace.split('.')[-1]
     if 'FormRecord' in str(new_class):
         object_name += 'Form'
@@ -50,11 +46,11 @@ def add_class(original_object, new_class, initialize=False, block_super=True):
                                      (new_class, original_object.__class__,), {})
 
     if initialize:
-        new_class.__init__(original_object, block_super=block_super)
+        new_class.__init__(original_object, block_super=True)
         if original_object._mdata is None:
             # Should only happen for tests for utils like MultiLanguageUtils
             # Typically the mdata gets initialized in the object form initers
             original_object._mdata = {}
-        new_class._init_metadata(original_object, block_super=block_super)
-        new_class._init_map(original_object, block_super=block_super)
+        new_class._init_metadata(original_object, block_super=True)
+        new_class._init_map(original_object, block_super=True)
     return original_object

--- a/tests/records/utilities.py
+++ b/tests/records/utilities.py
@@ -31,12 +31,16 @@ TEST_OBJECT_MAP = {
 }
 
 
-def add_class(original_object, new_class, initialize=False):
+def add_class(original_object, new_class, initialize=False, block_super=True):
     """The records tests require that we instantiate simple objects for each record class. With the current
         record schema, where we modify the object's __class__.__bases__ instead of using .my_osid_object,
         this helper method takes care of adding the new record.
 
-    Optional flag to run init_metadata and init_map"""
+    initialize = Optional flag to run init_metadata and init_map
+    block_super = Optional flag to control init behavior. Typically don't need to provide a value, except for
+                    tests where you are adding a class that subclasses other classes you want initialized. i.e.
+                    edX Composition tests.
+    """
     object_name = original_object._namespace.split('.')[-1]
     if 'FormRecord' in str(new_class):
         object_name += 'Form'
@@ -46,11 +50,11 @@ def add_class(original_object, new_class, initialize=False):
                                      (new_class, original_object.__class__,), {})
 
     if initialize:
-        new_class.__init__(original_object, block_super=True)
+        new_class.__init__(original_object, block_super=block_super)
         if original_object._mdata is None:
             # Should only happen for tests for utils like MultiLanguageUtils
             # Typically the mdata gets initialized in the object form initers
             original_object._mdata = {}
-        new_class._init_metadata(original_object, block_super=True)
-        new_class._init_map(original_object, block_super=True)
+        new_class._init_metadata(original_object, block_super=block_super)
+        new_class._init_map(original_object, block_super=block_super)
     return original_object


### PR DESCRIPTION
Note that this also suppresses the terminal reporting of test coverage -- it was causing issues with Travis CI:

https://github.com/conda/conda/issues/6481
https://github.com/conda/conda/issues/6473
https://github.com/CVC4/CVC4/pull/1445
https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959

Instead of using the `filter_secrets` flag as indicated in some of the issues above, we just suppress coverage reporting to standard out.